### PR TITLE
Add flag node for extended resources in kubecollect config

### DIFF
--- a/clusterloader2/pkg/measurement/common/sysdig/manifests/kubecollect-configMap.yaml
+++ b/clusterloader2/pkg/measurement/common/sysdig/manifests/kubecollect-configMap.yaml
@@ -8,6 +8,7 @@
 {{$networkTopologyEnabled := DefaultParam .CL2_NETWORK_TOPOLOGY_ENABLED true}}
 {{$podsFromKubeletEnabled := DefaultParam .CL2_PODS_FROM_KUBELET_ENABLED false}}
 {{$bePushEnabled := DefaultParam .CL2_BE_PUSH_ENABLED false}}
+{{$nodeExtendedResourcesEnabled := DefaultParam .CL2_NODE_EXTENDED_RESOURCES_ENABLED false}}
 
 apiVersion: v1
 kind: ConfigMap
@@ -76,5 +77,6 @@ data:
           "port": 10250,
           "use_http": true
       },
-      "k8s_state_be_push_enabled": {{$bePushEnabled}}
+      "k8s_state_be_push_enabled": {{$bePushEnabled}},
+      "k8s_node_extended_resources_enabled": {{$nodeExtendedResourcesEnabled}}
     }


### PR DESCRIPTION
Update kubecollect config to include `k8s_node_extended_resources_enabled`
ref: https://github.com/draios/agent/pull/3449